### PR TITLE
Bug/truncated values when they contain equals signs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "type": "library",
     "homepage": "http://github.com/abrander/nagios-status",
     "license": "MIT",
+    "version": "1.0.0",
     "authors": [
         {
             "name": "Anders Brander",

--- a/src/NagiosBase.php
+++ b/src/NagiosBase.php
@@ -48,7 +48,7 @@ class NagiosBase implements \JsonSerializable {
 				break;
 			}
 
-			list($key, $value) = preg_split('/\t|=/', $line);
+			list($key, $value) = preg_split('/\t|=/', $line, 2);
 
 			if (array_key_exists($key, $this->fields)) {
 				$this->$key = self::unmarshal($value, $this->fields[$key]);


### PR DESCRIPTION
there was a problem here: 
https://github.com/abrander/nagios-status/blob/acc210e2cb0320ce911142eac90b9544b3809c2d/src/NagiosBase.php#L51

I added a limit in preg_split, so that the value doesn't get truncated when there is an quals sign (=) in the value. 

I also added a semantic versioning version. Hope that this is ok too. 